### PR TITLE
Update keybindings.md for clarity

### DIFF
--- a/content/en/docs/Reference/keybindings.md
+++ b/content/en/docs/Reference/keybindings.md
@@ -35,7 +35,7 @@ description: >
 |Configure Wifi|`⊞ Win`-`w`|
 |Enter Window Resize Mode|`⊞ Win`-`r`|
 |Change Window Size in Resize Mode|`⊞ Win`-`arrow keys`|
-|Increase or Decrease Window Gaps|`+` and `-`|
+|Increase or Decrease Window Gaps in Resize Mode|`+` and `-`|
 |Exit Resize Mode|`Escape` or `Enter`|
 |Kill Focused Window|`⊞ Win`-`Shift`-`q`|
 |Close Terminal|`Ctrl`-`d`|


### PR DESCRIPTION
New to Regolith and because this is not a nested list (like in the Helper) it was unclear that you needed to be in Resize Mode for `+ -` to change your gaps. I recently updated from 1.2 and believe there it was simply ⊞ Win-+/- so I assumed this was a bug until figuring out i needed to be in resize mode. 

Added "in Resize Mode" because this was the only line where that was not clear :)