### PR TITLE
French params

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -129,6 +129,9 @@ algolia_docsearch = false
 # Enable Lunr.js offline search
 offlineSearch = false
 
+[languages.fr.params]
+version_menu = "Versions"
+
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
@@ -152,6 +155,12 @@ enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 yes = 'Glad to hear it! Please <a href="https://github.com/regolith-linux/regolith-linux.github.io/issues/new">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/regolith-linux/regolith-linux.github.io/issues/new">tell us how we can improve</a>.'
+
+[languages.fr.params.ui.feedback]
+enable = true
+# The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
+yes = "Bonne nouvelle ! N'hésitez pas <a href=\"https://github.com/regolith-linux/regolith-linux.github.io/issues/new\">à nous dire quoi améliorer</a>."
+no = "Mince alors ! N'hésitez pas <a href=\"https://github.com/regolith-linux/regolith-linux.github.io/issues/new\">à nous dire quoi améliorer</a>."
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
@@ -186,6 +195,40 @@ name = "Slack"
 url = "https://regolith-linux.herokuapp.com/"
 icon = "fab fa-slack"
 desc = "Chat with contributors and users"
+
+[languages.fr.params.links]
+# End user relevant links. These will show up on left side of footer and in the community page if you have one.
+[[languages.fr.params.links.user]]
+name = "Liste de diffusion"
+url = "https://www.freelists.org/list/regolith-linux"
+icon = "fa fa-envelope"
+desc = "Être informé des nouvelles fonctionnalités et correctifs"
+[[languages.fr.params.links.user]]
+name ="Twitter"
+url = "https://twitter.com/RegolithL"
+icon = "fab fa-twitter"
+desc = "Suivez-nous sur Twitter pour les dernières nouvelles"
+[[languages.fr.params.links.user]]
+name ="Mastodon"
+url = "https://fosstodon.org/@regolith"
+icon = "fab fa-mastodon"
+desc = "Suivez-nous sur Mastodon pour les dernières nouvelles"
+[[languages.fr.params.links.user]]
+name ="Tickets Github"
+url = "https://github.com/regolith-linux/regolith-desktop/issues"
+icon = "fab fa-github"
+desc = "Parcourir ou créer un nouveau ticket (bug). Proposer une nouvelle fonctionnalité."
+# Developer relevant links. These will show up on right side of footer and in the community page if you have one.
+[[languages.fr.params.links.developer]]
+name = "GitHub"
+url = "https://github.com/regolith-linux"
+icon = "fab fa-github"
+desc = "Le développement c'est par ici !"
+[[languages.fr.params.links.developer]]
+name = "Slack"
+url = "https://regolith-linux.herokuapp.com/"
+icon = "fab fa-slack"
+desc = "Discuster avec les contributeurs et les utilisateurs."
 
 # Versions
 [[params.versions]]

--- a/content/fr/download/_index.md
+++ b/content/fr/download/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Téléchargement"
-linkTitle: "Téléchargement"
+title: "Télécharger"
+linkTitle: "Télécharger"
 weight: 20
 menu:
   main:
@@ -9,7 +9,7 @@ menu:
 <section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
 	<div class="container text-center td-arrow-down">
 		<span class="h4 mb-0">
-<h1><i class="fas fa-cloud-download-alt ml-2 "></i> Obtenir Regolith</h1>
+<h1><i class="fas fa-cloud-download-alt ml-2 "></i> Télécharger Regolith</h1>
 
 <p>Regolith est disponible sous forme d'<b>ISO autonome</b> qui peut être installée comme un système d'exploitation Linux à part entière, et sous forme de "<b>personal package archive</b>" (PPA) qui installe Regolith sur une installation existante d'Ubuntu 18.04 ou 20.04. Cette page fournit les instructions de base pour installer et mettre à jour Regolith rapidement. Une <a href="../docs/getting-started/install">documentation complète</a> est disponible.</p>
 </span>

--- a/content/fr/interact/_index.md
+++ b/content/fr/interact/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Interagir
+title: Participer
 menu:
   main:
     weight: 40


### PR DESCRIPTION
Translated the `[params.links]` key/value pairs in order to have a fully translated Interact page.
I've also translated the "Releases" menu in the `[params]` section, but only included that one key/value pair. It looks like the other key/value pairs fallback to the default (English) but I'd be worth a second look by someone that knows more about how i18n works in Hugo (@moritzheiber :) ).