### PR TITLE
Update install.md

### DIFF
--- a/content/en/docs/Getting started/install.md
+++ b/content/en/docs/Getting started/install.md
@@ -46,7 +46,7 @@ The Unstable PPA `ppa:regolith-linux/release` is currently hosting Regolith 1.4.
 $ apt policy | grep regolith
 # Some info w/ URLs will be returned.  Assuming http://ppa.launchpad.net/regolith-linux/release/ubuntu is returned:
 $ sudo add-apt-repository --remove ppa:regolith-linux/release # remove release PPA
-$ sudo add-apt-repository ppa:regolith-linux/release
+$ sudo add-apt-repository ppa:regolith-linux/stable
 $ sudo apt update && sudo apt dist-upgrade
 $ sudo apt install i3xrocks-net-traffic i3xrocks-cpu-usage i3xrocks-time #also consider i3xrocks-battery i3xrocks-memory i3xrocks-weather
 ```


### PR DESCRIPTION
The upgrade instructions removed the release ppa uri and adds it back. I think the second one should be pointing to stable as proposed.