### PR TITLE
docs: add missing word to compositors page

### DIFF
--- a/content/en/docs/Customize/compositors.md
+++ b/content/en/docs/Customize/compositors.md
@@ -10,7 +10,7 @@ description: >
 Pay special attention to this section if you are experiencing odd visual glitches or slow graphics performance.
 {{% /pageinfo %}}
 
-As mentioned previously, a compositor is a UI component that visual effects to windows before they are rendered on-screen.  Many desktop environments integrate a compositor directly into the window manager, making it difficult to switch out or disable.  In Regolith, the compositor is defined as a pluggable "extension point" in the packaging system. This means that compositors can be switched out simply by installing the packages that contain them.  The underlying packaging system will ensure there are no conflicts and that all the dependencies of a given compositor are also installed.
+As mentioned previously, a compositor is a UI component that applies visual effects to windows before they are rendered on-screen.  Many desktop environments integrate a compositor directly into the window manager, making it difficult to switch out or disable.  In Regolith, the compositor is defined as a pluggable "extension point" in the packaging system. This means that compositors can be switched out simply by installing the packages that contain them.  The underlying packaging system will ensure there are no conflicts and that all the dependencies of a given compositor are also installed.
 
 ## Finding Available Compositors
 


### PR DESCRIPTION
While reading the docs I stumbled over a page that was missing a word in a sentence.