### PR TITLE
Remove dollar signs in front of commands

### DIFF
--- a/public/download/index.html
+++ b/public/download/index.html
@@ -209,8 +209,8 @@ if (!doNotTrack) {
 					</ul>
 					To install Regolith Desktop from the <code>release</code> PPA:
 					<pre class="border rounded p-2">
-$ sudo add-apt-repository ppa:regolith-linux/release
-$ sudo apt install regolith-desktop i3xrocks-net-traffic i3xrocks-cpu-usage i3xrocks-time</pre>
+sudo add-apt-repository ppa:regolith-linux/release
+sudo apt install regolith-desktop i3xrocks-net-traffic i3xrocks-cpu-usage i3xrocks-time</pre>
 					Learn more about <a href="https://help.ubuntu.com/community/Repositories/CommandLine#Adding_Launchpad_PPA_Repositories">adding PPAs here</a>, and more about <a href="../docs/getting-started/install/#ppa-sources">PPAs that Regolith provides here</a>.
 				</p>
     </div>


### PR DESCRIPTION
When going to copy the installation commands for Regolith, I (and I assume most people) double/triple click to select the line and copy + paste. When doing this with the dollar signs in front of the commands it gives an invalid command. There is no need for the dollar signs here and it saves everyone a little bit of time and frustration by not having them.