### PR TITLE
Fixed typo in '/content/en/docs/HowTo/override-xres.md'.

### DIFF
--- a/content/en/docs/HowTo/override-xres.md
+++ b/content/en/docs/HowTo/override-xres.md
@@ -109,4 +109,4 @@ Regolith generates many of these values from a canonical set of definitions.  Se
 
 # Further Reading
 
-See the [reference page for configrations](../../reference/configurations) for more details about config files in Regolith.
+See the [reference page for configurations](../../reference/configurations) for more details about config files in Regolith.


### PR DESCRIPTION
Before:
![Screenshot from 2021-01-16 20-58-12](https://user-images.githubusercontent.com/42870679/104815904-a1754a80-583d-11eb-8c1d-11cd97c97bee.png)
After:
![Screenshot from 2021-01-16 21-11-18](https://user-images.githubusercontent.com/42870679/104816207-886d9900-583f-11eb-9a39-5fbc4fb56664.png)
Please ignore the font size difference between the two images. (Due to screenshots taken)