### PR TITLE
The PPA link isn't working

### DIFF
--- a/content/en/docs/Getting started/install.md
+++ b/content/en/docs/Getting started/install.md
@@ -28,7 +28,7 @@ $ sudo apt update && sudo apt dist-upgrade
 1. Add the Regolith release PPA to your system: (See below about [PPA sources](#ppa-sources) for other package archives.)
 
 ```console
-$ sudo add-apt-repository ppa:regolith-linux/release
+$ sudo add-apt-repository -y ppa:regolith-linux/stable
 ```
 
 2. Install the Regolith desktop package ([see below for other desktop packages](#desktop-packages) available):


### PR DESCRIPTION
Changed the PPA url, on /release isn’t working. :+1: 
Tried on Ubuntu 21.04
